### PR TITLE
Add 'bypass login' functionality back in.  Add watch task to gulpfile.

### DIFF
--- a/src/MCM.KidsIdApp/gulpfile.js
+++ b/src/MCM.KidsIdApp/gulpfile.js
@@ -134,11 +134,15 @@ gulp.task("scripts", function () {
             target: "es5"
         });
     }
-    gulp.src("./www/scripts/**/*.ts")
+    gulp.src(paths.typeScriptSources)
         .pipe(sourcemaps.init())
         .pipe(tsConfig)
         .pipe(sourcemaps.write('.'))
         .pipe(gulp.dest("./www/scripts"));
+});
+
+gulp.task('watch', function () {
+    gulp.watch(paths.typeScriptSources, ['scripts']);
 });
 
 gulp.task("build", ["sass","scripts"], function () {

--- a/src/MCM.KidsIdApp/www/scripts/controllers/LoginController.ts
+++ b/src/MCM.KidsIdApp/www/scripts/controllers/LoginController.ts
@@ -25,20 +25,24 @@ module MCM {
 
     public signIn (service) {
         const that = this;
-        var mobileService = new WindowsAzure.MobileServiceClient(
-            "http://mobilekidsidapp.azurewebsites.net",
-            null
-        );
-        mobileService.login(service).done(
-            function success(user) {
-                that.userService.someMethod('foo')
-                    .then( function (param) {
-                        console.log('in .then with param=' + param);
-                        that.state.go('landing');
-                    });
-            }, function error(error) {
-                console.error('Failed to login: ', error);
-            });
+        if (service == 'test') {
+            that.state.go('landing');
+        } else {
+            var mobileService = new WindowsAzure.MobileServiceClient(
+                "http://mobilekidsidapp.azurewebsites.net",
+                null
+            );
+            mobileService.login(service).done(
+                function success(user) {
+                    that.userService.someMethod('foo')
+                        .then(function (param) {
+                            console.log('in .then with param=' + param);
+                            that.state.go('landing');
+                        });
+                }, function error(error) {
+                    console.error('Failed to login: ', error);
+                });
+        }
     }
   }
 }


### PR DESCRIPTION
The 'bypass login' functionality (issue #77) got lost when code was moved from app.js into LoginController.ts, so just adding it back in.

Also added a 'watch' task to gulpfile which triggers scripts task (issue #69).  If you choose to run the watch task, typescript automatically gets converted to javascript whenever a typescript file is saved.  This task does not run as a result of running any other task.