### PR TITLE
#165: Add 'GetContactInfoForId' to ContactPicker service. Implement PhoneContact control

### DIFF
--- a/src/MobileKidsIdApp/MobileKidsIdApp/MobileKidsIdApp.UWP/Services/ContactPicker.cs
+++ b/src/MobileKidsIdApp/MobileKidsIdApp/MobileKidsIdApp.UWP/Services/ContactPicker.cs
@@ -12,6 +12,7 @@ namespace MobileKidsIdApp.UWP.Services
 {
     public class ContactPicker : IContactPicker
     {
+
         public async Task<ContactInfo> GetSelectedContactInfo()
         {
 
@@ -25,18 +26,32 @@ namespace MobileKidsIdApp.UWP.Services
 
             if (contact != null)
             {
-                return new ContactInfo() {
-                    Id = contact.Id,
-                    FamilyName = contact.LastName,
-                    AdditionalName = contact.MiddleName,
-                    GivenName = contact.FirstName
-                };
+                return CreateContactInfo(contact);
             }
             else
             {
                 return null;
             }
         }
-        
+
+        private ContactInfo CreateContactInfo(WinContacts.Contact contact)
+        {
+            return new ContactInfo()
+            {
+                Id = contact.Id,
+                FamilyName = contact.LastName,
+                AdditionalName = contact.MiddleName,
+                GivenName = contact.FirstName
+            };
+        }
+
+        public async Task<ContactInfo> GetContactInfoForId(string id)
+        {
+            var store = await WinContacts.ContactManager
+                    .RequestStoreAsync(WinContacts.ContactStoreAccessType.AllContactsReadOnly);
+            var contact = await store.GetContactAsync(id);
+            return CreateContactInfo(contact);
+        }
+
     }
 }

--- a/src/MobileKidsIdApp/MobileKidsIdApp/MobileKidsIdApp.iOS/Services/ContactPicker.cs
+++ b/src/MobileKidsIdApp/MobileKidsIdApp/MobileKidsIdApp.iOS/Services/ContactPicker.cs
@@ -22,6 +22,7 @@ namespace MobileKidsIdApp.iOS.Services
     /// </remarks>
     public class ContactPicker :  IContactPicker
     {
+
         public Task<ContactInfo> GetSelectedContactInfo()
         {
             var picker = new CNContactPickerViewController()
@@ -57,6 +58,11 @@ namespace MobileKidsIdApp.iOS.Services
 
             return tcs.Task;
             
+        }
+
+        public Task<ContactInfo> GetContactInfoForId(string id)
+        {
+            throw new NotImplementedException($"{nameof(GetContactInfoForId)} not yet implemented for iOS.");
         }
     }
 

--- a/src/MobileKidsIdApp/MobileKidsIdApp/MobileKidsIdApp/Controls/PhoneContact.xaml
+++ b/src/MobileKidsIdApp/MobileKidsIdApp/MobileKidsIdApp/Controls/PhoneContact.xaml
@@ -1,6 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+<Grid xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="MobileKidsIdApp.Controls.PhoneContact">
-    <Label Text="{Binding MainText}" VerticalOptions="Center" HorizontalOptions="Center" />
-</ContentPage>
+  <Grid.RowDefinitions>
+    <RowDefinition />
+    <RowDefinition />
+    <RowDefinition />
+  </Grid.RowDefinitions>
+  <Grid.ColumnDefinitions>
+    <ColumnDefinition />
+    <ColumnDefinition />
+  </Grid.ColumnDefinitions>
+  <Label Text="First Name:" VerticalOptions="Center" HorizontalOptions="Start" />
+  <Label Text="{Binding GivenName}" Grid.Column="1" VerticalOptions="Center" HorizontalOptions="Start" />
+  <Label Text="Last Name:" Grid.Row="1" VerticalOptions="Center" HorizontalOptions="Start" />
+  <Label Text="{Binding FamilyName}" Grid.Column="1" Grid.Row="1" VerticalOptions="Center" HorizontalOptions="Start" />
+</Grid>

--- a/src/MobileKidsIdApp/MobileKidsIdApp/MobileKidsIdApp/Controls/PhoneContact.xaml.cs
+++ b/src/MobileKidsIdApp/MobileKidsIdApp/MobileKidsIdApp/Controls/PhoneContact.xaml.cs
@@ -8,7 +8,7 @@ using Xamarin.Forms;
 
 namespace MobileKidsIdApp.Controls
 {
-    public partial class PhoneContact : ContentPage
+    public partial class PhoneContact : Grid
     {
         public PhoneContact()
         {

--- a/src/MobileKidsIdApp/MobileKidsIdApp/MobileKidsIdApp/Services/IContactPicker.cs
+++ b/src/MobileKidsIdApp/MobileKidsIdApp/MobileKidsIdApp/Services/IContactPicker.cs
@@ -9,5 +9,7 @@ namespace MobileKidsIdApp.Services
     public interface IContactPicker
     {
         Task<ViewModels.ContactInfo> GetSelectedContactInfo();
+
+        Task<ViewModels.ContactInfo> GetContactInfoForId(string id);
     }
 }

--- a/src/MobileKidsIdApp/MobileKidsIdApp/MobileKidsIdApp/ViewModels/BasicDetails.cs
+++ b/src/MobileKidsIdApp/MobileKidsIdApp/MobileKidsIdApp/ViewModels/BasicDetails.cs
@@ -13,6 +13,8 @@ namespace MobileKidsIdApp.ViewModels
 {
     public class BasicDetails : ViewModelBase<Models.ChildDetails>
     {
+        private ContactInfo _contact;
+
         public ICommand ChangeContactCommand { get; private set; }
 
         public BasicDetails(Models.ChildDetails details)
@@ -26,6 +28,7 @@ namespace MobileKidsIdApp.ViewModels
                 }
                 else
                 {
+                    _contact = contact;
                     Model.ContactId = contact.Id;
 
                     //Only overwrite name fields if they were blank.
@@ -35,6 +38,8 @@ namespace MobileKidsIdApp.ViewModels
                         Model.AdditionalName = contact.AdditionalName;
                     if (string.IsNullOrEmpty(Model.GivenName))
                         Model.GivenName = contact.GivenName;
+                    
+                    OnPropertyChanged(nameof(Contact));
                 }
             });
 
@@ -42,10 +47,12 @@ namespace MobileKidsIdApp.ViewModels
         }
         
 
-        protected override Task<ChildDetails> DoInitAsync()
+        protected override async Task<ChildDetails> DoInitAsync()
         {
-            //Must override default implmentation that throws NotImplementedException.
-            return Task.FromResult(Model);
+            _contact = await DependencyService.Get<IContactPicker>().GetContactInfoForId(Model.ContactId);
+            return Model;
         }
+
+        public ContactInfo Contact { get { return _contact; } }
     }
 }

--- a/src/MobileKidsIdApp/MobileKidsIdApp/MobileKidsIdApp/ViewModels/ChildprofileList.cs
+++ b/src/MobileKidsIdApp/MobileKidsIdApp/MobileKidsIdApp/ViewModels/ChildprofileList.cs
@@ -40,13 +40,19 @@ namespace MobileKidsIdApp.ViewModels
 
         private async void Model_AddedNew(object sender, Csla.Core.AddedNewEventArgs<Child> e)
         {
-            await ShowChild(e.NewObject);
+            await ShowChild(e.NewObject, true);
         }
 
-        public async Task ShowChild(Child child)
+        public async Task ShowChild(Child child, bool? isNew = false)
         {
-            await App.RootPage.Navigation.PushAsync(
-                new Views.ChildProfileItem { BindingContext = await new ChildProfileItem(child).InitAsync() });
+            var childProfileItemVM = new ChildProfileItem(child);
+            await childProfileItemVM.InitAsync();
+            await App.RootPage.Navigation.PushAsync(new Views.ChildProfileItem { BindingContext = childProfileItemVM });
+            if (isNew == true)
+            {
+                //Go directly to the basic details page for a new child.
+                childProfileItemVM.EditChildDetailsCommand.Execute(null);
+            }
         }
     }
 }

--- a/src/MobileKidsIdApp/MobileKidsIdApp/MobileKidsIdApp/Views/BasicDetails.xaml
+++ b/src/MobileKidsIdApp/MobileKidsIdApp/MobileKidsIdApp/Views/BasicDetails.xaml
@@ -2,6 +2,7 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="MobileKidsIdApp.Views.BasicDetails"
+             xmlns:controls="clr-namespace:MobileKidsIdApp.Controls;assembly=MobileKidsIdApp"
              Title="Basic details">
     <TableView Intent="Form">
         <TableView.Root>
@@ -16,10 +17,12 @@
                 </ViewCell>
             </TableSection>
             <TableSection Title="Contact">
-                <ViewCell>
-                    <Label Text="{Binding ContactId}"/>
-                    <Button Text="Change" Command="{Binding ChangeContactCommand}" />
-                </ViewCell>
+                  <ViewCell>
+                    <StackLayout Orientation="Vertical">
+                      <Button Text="Change" Command="{Binding ChangeContactCommand}" />
+                      <controls:PhoneContact BindingContext="{Binding Contact}" Margin="3" />
+                    </StackLayout>
+                  </ViewCell>
             </TableSection>
         </TableView.Root>
     </TableView>


### PR DESCRIPTION
'GetContactInfoForId' only implemented for UWP and Android. PhoneContact control now shown on BasicDetails page but still needs adding to views like FamilyMemberList and FriendList.