### PR TITLE
#230 : Fix for Static Content Load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,3 +245,6 @@ src/MCM.KidsIdApp/www/scripts/appBundle.js
 src/MCM.KidsIdApp/www/lib/ionic-datepicker
 /src/MCM.KidsIdApp/www/lib/blob-util
 src/MCM.KidsIdApp.MobileApi/Web.Debug.config
+
+# Mac OS Hidden directories
+.DS_Store

--- a/src/MobileKidsIdApp/MobileKidsIdApp.Android/Assets/default.css
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.Android/Assets/default.css
@@ -1,0 +1,5 @@
+﻿html, body {
+    margin: 10;
+    padding: 10;
+    font-family: sans-serif;
+}

--- a/src/MobileKidsIdApp/MobileKidsIdApp.Android/MobileKidsIdApp.Android.csproj
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.Android/MobileKidsIdApp.Android.csproj
@@ -107,5 +107,8 @@
       <Name>MobileKidsIdApp</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <AndroidAsset Include="Assets\default.css" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>

--- a/src/MobileKidsIdApp/MobileKidsIdApp.UWP/MobileKidsIdApp.UWP.csproj
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.UWP/MobileKidsIdApp.UWP.csproj
@@ -134,6 +134,7 @@
     <Content Include="Assets\Wide310x150Logo.scale-100.png" />
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
     <Content Include="Assets\Wide310x150Logo.scale-400.png" />
+    <Content Include="default.css" />
     <Content Include="Properties\Default.rd.xml" />
   </ItemGroup>
   <ItemGroup>

--- a/src/MobileKidsIdApp/MobileKidsIdApp.iOS/MobileKidsIdApp.iOS.csproj
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.iOS/MobileKidsIdApp.iOS.csproj
@@ -166,4 +166,7 @@
       <Name>MobileKidsIdApp</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <BundleResource Include="Resources\default.css" />
+  </ItemGroup>
 </Project>

--- a/src/MobileKidsIdApp/MobileKidsIdApp.iOS/MobileKidsIdApp.iOS.csproj
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.iOS/MobileKidsIdApp.iOS.csproj
@@ -162,7 +162,7 @@
       <Name>MobileKidsIdApp.Models</Name>
     </ProjectReference>
     <ProjectReference Include="..\MobileKidsIdApp\MobileKidsIdApp.csproj">
-      <Project>{BAC7D892-1C11-47CA-8932-9F4018C816B6}</Project>
+      <Project>{C16814AE-85B2-4DF5-89AB-957D6D68D946}</Project>
       <Name>MobileKidsIdApp</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/MobileKidsIdApp/MobileKidsIdApp/MobileKidsIdApp.csproj
+++ b/src/MobileKidsIdApp/MobileKidsIdApp/MobileKidsIdApp.csproj
@@ -13,4 +13,24 @@
         <ProjectReference Include="..\..\MobileKidsIdApp.DataAccess\MobileKidsIdApp.DataAccess.csproj" />
         <ProjectReference Include="..\..\MobileKidsIdApp.Models\MobileKidsIdApp.Models.csproj" />
     </ItemGroup>
+    <ItemGroup>
+      <None Remove="Resources\abduction.html" />
+      <None Remove="Resources\amberalert.html" />
+      <None Remove="Resources\disasterprep.html" />
+      <None Remove="Resources\dna.html" />
+      <None Remove="Resources\international.html" />
+      <None Remove="Resources\missing.html" />
+      <None Remove="Resources\runaway.html" />
+      <None Remove="Resources\safety.html" />
+    </ItemGroup>
+    <ItemGroup>
+      <EmbeddedResource Include="Resources\abduction.html" />
+      <EmbeddedResource Include="Resources\amberalert.html" />
+      <EmbeddedResource Include="Resources\disasterprep.html" />
+      <EmbeddedResource Include="Resources\dna.html" />
+      <EmbeddedResource Include="Resources\international.html" />
+      <EmbeddedResource Include="Resources\missing.html" />
+      <EmbeddedResource Include="Resources\runaway.html" />
+      <EmbeddedResource Include="Resources\safety.html" />
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
This build (#230) restores static HTML content loading and CSS styling for all three builds in the new .NET Standard projects. I also snuck in an update to the .gitignore file to filter out some Mac OS junk.
