### PR TITLE
Issue #206 - Set up app for App Center

### DIFF
--- a/src/MobileKidsIdApp/MobileKidsIdApp.Android/MainActivity.cs
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.Android/MainActivity.cs
@@ -3,15 +3,12 @@
 using Android.App;
 using Android.Content.PM;
 using Android.OS;
-using System.Threading.Tasks;
-using MobileKidsIdApp.Models;
-using MobileKidsIdApp.Services;
 using MobileKidsIdApp.Droid.Services;
 using Android.Content;
 
 namespace MobileKidsIdApp.Droid
 {
-    [Activity(Label = "MobileKidsIdApp", Icon = "@mipmap/icon", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
+    [Activity(Label = "Kids Id Kit", Icon = "@mipmap/icon", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
     public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
     {
         protected override void OnCreate(Bundle bundle)

--- a/src/MobileKidsIdApp/MobileKidsIdApp.Android/MobileKidsIdApp.Android.csproj
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.Android/MobileKidsIdApp.Android.csproj
@@ -39,6 +39,9 @@
     <WarningLevel>4</WarningLevel>
     <AndroidManagedSymbols>true</AndroidManagedSymbols>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+    <AndroidLinkMode>Full</AndroidLinkMode>
+    <AndroidSupportedAbis />
+    <EnableProguard>true</EnableProguard>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />

--- a/src/MobileKidsIdApp/MobileKidsIdApp.Android/Properties/AndroidManifest.xml
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.Android/Properties/AndroidManifest.xml
@@ -2,5 +2,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.HumanitarianToolbox.KidsIdKit" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="27" />
 	<uses-permission android:name="android.permission.READ_CONTACTS" />
-	<application android:label="MobileKidsIdApp.Droid" android:icon="@mipmap/icon"></application>
+	<application android:label="Kids Id Kit" android:icon="@mipmap/icon"></application>
 </manifest>

--- a/src/MobileKidsIdApp/MobileKidsIdApp.Android/Properties/AndroidManifest.xml
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.MobileKidsIdApp" android:installLocation="auto">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.HumanitarianToolbox.KidsIdKit" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="27" />
 	<uses-permission android:name="android.permission.READ_CONTACTS" />
 	<application android:label="MobileKidsIdApp.Droid" android:icon="@mipmap/icon"></application>

--- a/src/MobileKidsIdApp/MobileKidsIdApp.Android/Properties/AssemblyInfo.cs
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.Android/Properties/AssemblyInfo.cs
@@ -7,11 +7,11 @@ using Android.App;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("MobileKidsIdApp.Droid")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Missing Children Minnesota Kids Id Kit")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Humanitarian Toolbox and Missing Children Minnesota")]
 [assembly: AssemblyProduct("MobileKidsIdApp.Droid")]
-[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
@@ -32,3 +32,9 @@ using Android.App;
 // Add some common permissions, these can be removed if not needed
 [assembly: UsesPermission(Android.Manifest.Permission.Internet)]
 [assembly: UsesPermission(Android.Manifest.Permission.WriteExternalStorage)]
+
+#if DEBUG
+[assembly: Application(Debuggable = true)]
+#else
+[assembly: Application(Debuggable = false)]
+#endif

--- a/src/MobileKidsIdApp/MobileKidsIdApp.UWP/Package.appxmanifest
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.UWP/Package.appxmanifest
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
-  <Identity Name="d71203cb-6cdd-4962-8fd0-26eb752b4ec7" Publisher="CN=HTBox" Version="1.0.0.0" />
+  <Identity Name="com.HumanitarianToolbox.KidsIdKit" Publisher="CN=HTBox" Version="1.0.0.0" />
   <mp:PhoneIdentity PhoneProductId="ec0cc741-fd3e-485c-81be-68815c480690" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
-    <DisplayName>MobileKidsIdApp.UWP</DisplayName>
+    <DisplayName>com.HumanitarianToolbox.KidsIdKit</DisplayName>
     <PublisherDisplayName>e86f0349-1b0f-4755-97fd-386280c04413</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>

--- a/src/MobileKidsIdApp/MobileKidsIdApp.UWP/Properties/AssemblyInfo.cs
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.UWP/Properties/AssemblyInfo.cs
@@ -6,11 +6,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("MobileKidsIdApp.UWP")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Missing Children Minnesota Kids Id Kit")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Humanitarian Toolbox and Missing Children Minnesota")]
 [assembly: AssemblyProduct("MobileKidsIdApp.UWP")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/MobileKidsIdApp/MobileKidsIdApp.iOS/Info.plist
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.iOS/Info.plist
@@ -31,7 +31,7 @@
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>CFBundleName</key>
-	<string>MobileKidsIdApp</string>
+	<string>Kids Id Kit</string>
 	<key>XSAppIconAssets</key>
 	<string>Assets.xcassets/AppIcon.appiconset</string>
 	<key>CFBundleShortVersionString</key>

--- a/src/MobileKidsIdApp/MobileKidsIdApp.iOS/Info.plist
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.iOS/Info.plist
@@ -25,7 +25,7 @@
 	<key>CFBundleDisplayName</key>
 	<string>MobileKidsIdKit</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.MissingChildrenMinnesota.MobileKidsIdKit</string>
+	<string>com.HumanitarianToolbox.KidsIdKit</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>UILaunchStoryboardName</key>
@@ -34,5 +34,7 @@
 	<string>MobileKidsIdApp</string>
 	<key>XSAppIconAssets</key>
 	<string>Assets.xcassets/AppIcon.appiconset</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1</string>
 </dict>
 </plist>

--- a/src/MobileKidsIdApp/MobileKidsIdApp.iOS/Info.plist
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.iOS/Info.plist
@@ -23,7 +23,7 @@
 	<key>MinimumOSVersion</key>
 	<string>8.0</string>
 	<key>CFBundleDisplayName</key>
-	<string>MobileKidsIdKit</string>
+	<string>Kids Id Kit</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.HumanitarianToolbox.KidsIdKit</string>
 	<key>CFBundleVersion</key>

--- a/src/MobileKidsIdApp/MobileKidsIdApp.iOS/Properties/AssemblyInfo.cs
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.iOS/Properties/AssemblyInfo.cs
@@ -6,11 +6,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("MobileKidsIdApp.iOS")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Missing Children Minnesota Kids Id Kit")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Humanitarian Toolbox and Missing Children Minnesota")]
 [assembly: AssemblyProduct("MobileKidsIdApp.iOS")]
-[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
#206 

Normalized the package name for the 3 apps. 

This will help us get iOS cert/provisioning profile in place for the App Center builds, as a pre-requisite for generating those files.