### PR TITLE
#295 - Fixes Dismissal of Login Screen on Android

### DIFF
--- a/src/MobileKidsIdApp/MobileKidsIdApp/App.xaml.cs
+++ b/src/MobileKidsIdApp/MobileKidsIdApp/App.xaml.cs
@@ -1,5 +1,6 @@
 using MobileKidsIdApp.Services;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
@@ -12,46 +13,34 @@ namespace MobileKidsIdApp
         public static NavigationPage RootPage { private set; get; }
         public static ViewModels.ChildProfileList CurrentFamily { get; set; }
 
+
         public App ()
 		{
 			InitializeComponent();
 
             Csla.ApplicationContext.ContextManager = new Models.ApplicationContextManager();
 
-            RootPage = new NavigationPage(new Views.Landing { BindingContext = new ViewModels.Landing() });
-            MainPage = RootPage;
-        }
-
-        protected override async void OnStart ()
-		{
-            await CheckUserLogin();
-        }
-
-        protected override void OnSleep ()
-		{
-			// Handle when your app sleeps
-		}
-
-		protected override async void OnResume ()
-		{
-            await CheckUserLogin();
-        }
-
-        private static async Task CheckUserLogin()
-        {
             if (Csla.ApplicationContext.User == null)
                 Csla.ApplicationContext.User = new Csla.Security.UnauthenticatedPrincipal();
 
             if (!Csla.ApplicationContext.User.Identity.IsAuthenticated)
             {
-                await RootPage.Navigation.PushModalAsync(new NavigationPage(new Views.Login { BindingContext = new ViewModels.Login() }));
+                RootPage = new NavigationPage(new Views.Login { BindingContext = new ViewModels.Login() });
             }
+            else
+            {
+                RootPage = new NavigationPage(new Views.Landing { BindingContext = new ViewModels.Landing() });
+            }
+
+            MainPage = RootPage;
         }
+
 
         internal static async Task Logout()
         {
-            Csla.ApplicationContext.User = new Csla.Security.UnauthenticatedPrincipal();
-            await CheckUserLogin();
+            RootPage.Navigation.InsertPageBefore(new NavigationPage(new Views.Login { BindingContext = new ViewModels.Login() }),
+                                                 RootPage.Navigation.NavigationStack.First());
+            await RootPage.Navigation.PopAsync();
         }
     }
 }

--- a/src/MobileKidsIdApp/MobileKidsIdApp/ViewModels/Login.cs
+++ b/src/MobileKidsIdApp/MobileKidsIdApp/ViewModels/Login.cs
@@ -51,7 +51,9 @@ namespace MobileKidsIdApp.ViewModels
             Csla.ApplicationContext.User = new Models.AppPrincipal(identity);
             if (Csla.ApplicationContext.User.Identity.IsAuthenticated)
             {
-                await App.RootPage.Navigation.PopModalAsync();
+                App.RootPage.Navigation.InsertPageBefore(new NavigationPage(new Views.Landing { BindingContext = new ViewModels.Landing() }),
+                                                         App.RootPage.Navigation.NavigationStack.First());
+                await App.RootPage.Navigation.PopAsync();
             }
             else
             {


### PR DESCRIPTION
Replaces modal display of login view with manipulation of NavigationStack order. Checks CSLA context for login state.

Based on example from Xamarin:
https://github.com/xamarin/xamarin-forms-samples/tree/master/Navigation/LoginFlow 