### PR TITLE
Don't set System.Thread.CurrentPrincipal because that is optimized away

### DIFF
--- a/src/MobileKidsIdApp.Models/ApplicationContextManager.cs
+++ b/src/MobileKidsIdApp.Models/ApplicationContextManager.cs
@@ -39,7 +39,6 @@ namespace MobileKidsIdApp.Models
         public override void SetUser(IPrincipal principal)
         {
             _principal = principal;
-            Thread.CurrentPrincipal = principal;
         }
     }
 }

--- a/src/MobileKidsIdApp/MobileKidsIdApp.iOS/MobileKidsIdApp.iOS.csproj
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.iOS/MobileKidsIdApp.iOS.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -56,6 +56,8 @@
     </CodesignProvision>
     <CodesignExtraArgs />
     <CodesignResourceRules />
+    <MtouchExtraArgs>
+    </MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>


### PR DESCRIPTION
#327 Don't set System.Thread.CurrentPrincipal because that is optimized away on iOS