### PR TITLE
Material design support

### DIFF
--- a/src/MobileKidsIdApp/MobileKidsIdApp.Android/MainActivity.cs
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.Android/MainActivity.cs
@@ -27,6 +27,7 @@ namespace MobileKidsIdApp.Droid
             base.OnCreate(bundle);
 
             global::Xamarin.Forms.Forms.Init(this, bundle);
+            global::Xamarin.Forms.FormsMaterial.Init(this, savedInstanceState);
 
             var formsApp = new App();
             formsApp.Init(PlatformInitializeContainer);

--- a/src/MobileKidsIdApp/MobileKidsIdApp.Android/MainActivity.cs
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.Android/MainActivity.cs
@@ -27,7 +27,7 @@ namespace MobileKidsIdApp.Droid
             base.OnCreate(bundle);
 
             global::Xamarin.Forms.Forms.Init(this, bundle);
-            global::Xamarin.Forms.FormsMaterial.Init(this, savedInstanceState);
+            global::Xamarin.Forms.FormsMaterial.Init(this, bundle);
 
             var formsApp = new App();
             formsApp.Init(PlatformInitializeContainer);

--- a/src/MobileKidsIdApp/MobileKidsIdApp.Android/MobileKidsIdApp.Android.csproj
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.Android/MobileKidsIdApp.Android.csproj
@@ -58,7 +58,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.6.0.800" />
+    <PackageReference Include="Xamarin.Forms" Version="4.6.0.847" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.1.0-rc3" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0" />
   <PackageReference Include="Xamarin.AndroidX.Browser">
@@ -75,6 +75,9 @@
   </PackageReference>
   <PackageReference Include="System.Text.Json">
     <Version>4.7.2</Version>
+  </PackageReference>
+  <PackageReference Include="Xamarin.Forms.Visual.Material">
+    <Version>4.6.0.847</Version>
   </PackageReference>
 </ItemGroup>
   <ItemGroup>

--- a/src/MobileKidsIdApp/MobileKidsIdApp.iOS/AppDelegate.cs
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.iOS/AppDelegate.cs
@@ -30,6 +30,7 @@ namespace MobileKidsIdApp.iOS
             SecureStorage.DefaultAccessible = SecAccessible.AlwaysThisDeviceOnly;
  
             global::Xamarin.Forms.Forms.Init();
+            global::Xamarin.Forms.FormsMaterial.Init();
 
             var formsApp = new App();
             formsApp.Init(PlatformInitializeContainer);

--- a/src/MobileKidsIdApp/MobileKidsIdApp.iOS/MobileKidsIdApp.iOS.csproj
+++ b/src/MobileKidsIdApp/MobileKidsIdApp.iOS/MobileKidsIdApp.iOS.csproj
@@ -170,7 +170,7 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.6.0.800" />
+    <PackageReference Include="Xamarin.Forms" Version="4.6.0.847" />
     <PackageReference Include="Xamarin.Essentials">
       <Version>1.5.3.2</Version>
     </PackageReference>
@@ -182,6 +182,9 @@
     </PackageReference>
     <PackageReference Include="Xamarin.TestCloud.Agent">
       <Version>0.21.9</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Forms.Visual.Material">
+      <Version>4.6.0.847</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/src/MobileKidsIdApp/MobileKidsIdApp/MobileKidsIdApp.csproj
+++ b/src/MobileKidsIdApp/MobileKidsIdApp/MobileKidsIdApp.csproj
@@ -11,10 +11,10 @@
       <LangVersion>8.0</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Xamarin.Forms" Version="4.6.0.800" />
         <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
         <PackageReference Include="Unity" Version="5.11.7" />
         <PackageReference Include="System.Text.Json" Version="4.7.2" />
+        <PackageReference Include="Xamarin.Forms.Visual.Material" Version="4.6.0.847" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MobileKidsIdApp/MobileKidsIdApp/Mvvm/ContentPageBase.cs
+++ b/src/MobileKidsIdApp/MobileKidsIdApp/Mvvm/ContentPageBase.cs
@@ -4,6 +4,8 @@ namespace MobileKidsIdApp
 {
     public abstract class ContentPageBase : ContentPage
     {
+        public ContentPageBase() => Visual = VisualMarker.Material;
+
         protected ViewModelBase ViewModel => BindingContext as ViewModelBase;
 
         protected override void OnAppearing() => ViewModel?.OnAppearing();

--- a/src/MobileKidsIdApp/MobileKidsIdApp/Services/FamilyRepository.storage.cs
+++ b/src/MobileKidsIdApp/MobileKidsIdApp/Services/FamilyRepository.storage.cs
@@ -17,7 +17,7 @@ namespace MobileKidsIdApp.Services
             if (File.Exists(FilePath))
             {
                 byte[] encrypted = File.ReadAllBytes(FilePath);
-                string json = Decrypt(encrypted).TrimEnd((char)0x0e);
+                string json = Decrypt(encrypted).TrimEnd((char)0x0e, (char)0x01);
                 return DeserializeChildren(json);
             }
 


### PR DESCRIPTION
- Added support for Google's Material design components for Xamarin.Forms. 
- Note: This defaults to the "filled" style for text entry. Using the "outline" style takes a bit of work since the components necessary in the XF OSS project are internal. 
- Fixed an issue with an additional padding char that occurs when encrypting/decrypting the json data. 